### PR TITLE
add relative positioning to html, body; add fixed positioning to .attention, for Firefox compatibility

### DIFF
--- a/css/threeStyle.css
+++ b/css/threeStyle.css
@@ -1,4 +1,5 @@
 html, body {
+    position: relative;
     font-family: arial;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
@@ -114,7 +115,7 @@ a:visited {
   border: 2px solid #fff;
   top: 21px;
   left: 21px;
-  position: absolute;
+  position: fixed;
 }
 
 #contact-div {


### PR DESCRIPTION
Firefox was displacing part of the "?" button and displaying the contact link too early.  Adding `position: fixed;` to `.attention` fixed the "?" button.  Then, adding `position: relative` to `body` actually fixed both issues.  I left the first fix because there's a joke in there somewhere.

Here's what was hapening:
![screenshot from 2015-07-08 01 09 03](https://cloud.githubusercontent.com/assets/1500628/8566132/b8797528-2510-11e5-8a6c-723971b0df6e.png)
